### PR TITLE
Use x-www-form-urlencoded payload to request access token

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -3,6 +3,7 @@ import koaSession from 'koa-session';
 import nanoid from 'nanoid';
 import fetch from 'node-fetch';
 import fs from 'fs';
+import { URLSearchParams } from 'url';
 import Log from './Log.mjs';
 
 let config = {
@@ -87,10 +88,7 @@ if(fs.existsSync('./config.json')) {
 		
 		let json = await fetch(app.config.tokenUrl, {
 			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json'
-			},
-			body: JSON.stringify({
+			body: new URLSearchParams({
 				client_id: authConfig.clientId,
 				client_secret: authConfig.clientSecret,
 				code: query.code,


### PR DESCRIPTION
According to the OAuth 2 specification the access token request should be using the "application/x-www-form-urlencoded" format.
https://tools.ietf.org/html/rfc6749#section-4.1.3

node-fetch automatically sets the correct header when using URLSearchParams
https://www.npmjs.com/package/node-fetch#post-with-form-parameters